### PR TITLE
feat: maximized windows stay maximized

### DIFF
--- a/GlazeWM.Domain/Containers/CommandHandlers/RedrawContainersHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/RedrawContainersHandler.cs
@@ -39,8 +39,8 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
       var windowsToRestore = windowsToRedraw
         .Where(
           (window) =>
-            window is not MinimizedWindow &&
-            window.HasWindowStyle(WindowStyles.Maximize | WindowStyles.Minimize)
+            (window is not MinimizedWindow && window.HasWindowStyle(WindowStyles.Minimize)) ||
+            (window is not MaximizedWindow && window.HasWindowStyle(WindowStyles.Maximize))
         )
         .ToList();
 
@@ -84,6 +84,9 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
         defaultFlags |= SetWindowPosFlags.ShowWindow;
       else
         defaultFlags |= SetWindowPosFlags.HideWindow;
+
+      if (window is MaximizedWindow)
+        defaultFlags |= SetWindowPosFlags.NoSize;
 
       // Transition display state depending on whether window will be shown/hidden.
       window.DisplayState = window.DisplayState switch

--- a/GlazeWM.Domain/Windows/EventHandlers/WindowLocationChangedHandler.cs
+++ b/GlazeWM.Domain/Windows/EventHandlers/WindowLocationChangedHandler.cs
@@ -59,6 +59,9 @@ namespace GlazeWM.Domain.Windows.EventHandlers
           Id = window.Id
         };
 
+        if (!window.HasSiblings() && window.Parent is not Workspace)
+          _bus.Invoke(new FlattenSplitContainerCommand(window.Parent as SplitContainer));
+
         _bus.Invoke(new ReplaceContainerCommand(maximizedWindow, window.Parent, window.Index));
       }
 

--- a/GlazeWM.Domain/Windows/EventHandlers/WindowLocationChangedHandler.cs
+++ b/GlazeWM.Domain/Windows/EventHandlers/WindowLocationChangedHandler.cs
@@ -1,18 +1,26 @@
+using System;
+using GlazeWM.Domain.Containers;
 using GlazeWM.Domain.Containers.Commands;
 using GlazeWM.Domain.Monitors.Commands;
+using GlazeWM.Domain.Workspaces;
 using GlazeWM.Infrastructure.Bussing;
 using GlazeWM.Infrastructure.Common.Events;
+using static GlazeWM.Infrastructure.WindowsApi.WindowsApiService;
 
 namespace GlazeWM.Domain.Windows.EventHandlers
 {
   internal sealed class WindowLocationChangedHandler : IEventHandler<WindowLocationChangedEvent>
   {
     private readonly Bus _bus;
+    private readonly ContainerService _containerService;
     private readonly WindowService _windowService;
 
-    public WindowLocationChangedHandler(Bus bus, WindowService windowService)
+    public WindowLocationChangedHandler(Bus bus,
+      WindowService windowService,
+      ContainerService containerService)
     {
       _bus = bus;
+      _containerService = containerService;
       _windowService = windowService;
     }
 
@@ -20,11 +28,101 @@ namespace GlazeWM.Domain.Windows.EventHandlers
     {
       var windowHandle = @event.WindowHandle;
 
+      HandleMaximizedWindow(windowHandle);
+
       if (!_windowService.AppBarHandles.Contains(windowHandle))
         return;
 
       _bus.Invoke(new RefreshMonitorStateCommand());
       _bus.Invoke(new RedrawContainersCommand());
+    }
+
+    private void HandleMaximizedWindow(IntPtr windowHandle)
+    {
+      var window = _windowService.GetWindowByHandle(windowHandle);
+      if (window is null)
+        return;
+
+      var windowPlacement = WindowService.GetPlacementOfHandle(windowHandle);
+      var isMaximized = windowPlacement.ShowCommand == ShowWindowFlags.Maximize;
+
+      if (isMaximized && window is not MaximizedWindow)
+      {
+        var previousState = WindowService.GetWindowType(window);
+        var maximizedWindow = new MaximizedWindow(
+          window.Handle,
+          window.FloatingPlacement,
+          window.BorderDelta,
+          previousState
+        )
+        {
+          Id = window.Id
+        };
+
+        _bus.Invoke(new ReplaceContainerCommand(maximizedWindow, window.Parent, window.Index));
+      }
+
+      if (!isMaximized && window is MaximizedWindow)
+      {
+        var restoredWindow = CreateWindowFromPreviousState(window as MaximizedWindow);
+
+        _bus.Invoke(new ReplaceContainerCommand(restoredWindow, window.Parent, window.Index));
+
+        if (restoredWindow is not TilingWindow)
+        {
+          // Needed to reposition the floating window
+          _bus.Invoke(new RedrawContainersCommand());
+          return;
+        }
+
+        var workspace = WorkspaceService.GetWorkspaceFromChildContainer(window);
+        var insertionTarget = workspace.LastFocusedDescendantOfType<IResizable>();
+
+        // Insert the created tiling window after the last focused descendant of the workspace.
+        if (insertionTarget == null)
+          _bus.Invoke(new MoveContainerWithinTreeCommand(restoredWindow, workspace, 0, true));
+        else
+          _bus.Invoke(
+            new MoveContainerWithinTreeCommand(
+              restoredWindow,
+              insertionTarget.Parent,
+              insertionTarget.Index + 1,
+              true
+            )
+          );
+
+        _containerService.ContainersToRedraw.Add(workspace);
+        _bus.Invoke(new RedrawContainersCommand());
+      }
+    }
+
+    private static Window CreateWindowFromPreviousState(MaximizedWindow window)
+    {
+      Window restoredWindow = window.PreviousState switch
+      {
+        WindowType.Floating => new FloatingWindow(
+          window.Handle,
+          window.FloatingPlacement,
+          window.BorderDelta
+        ),
+        WindowType.Fullscreen => new FullscreenWindow(
+          window.Handle,
+          window.FloatingPlacement,
+          window.BorderDelta
+        ),
+        // Set `SizePercentage` to 0 to correctly resize the container when moved within tree.
+        WindowType.Tiling => new TilingWindow(
+          window.Handle,
+          window.FloatingPlacement,
+          window.BorderDelta,
+          0
+        ),
+        WindowType.Maximized => throw new ArgumentException(null, nameof(window)),
+        _ => throw new ArgumentException(null, nameof(window)),
+      };
+
+      restoredWindow.Id = window.Id;
+      return restoredWindow;
     }
   }
 }

--- a/GlazeWM.Domain/Windows/EventHandlers/WindowLocationChangedHandler.cs
+++ b/GlazeWM.Domain/Windows/EventHandlers/WindowLocationChangedHandler.cs
@@ -70,29 +70,23 @@ namespace GlazeWM.Domain.Windows.EventHandlers
         _bus.Invoke(new RedrawContainersCommand());
       }
 
-      // Window is being unmaximized.
+      // Maximized window is being restored.
       if (!isMaximized && window is MaximizedWindow)
       {
         var restoredWindow = CreateWindowFromPreviousState(window as MaximizedWindow);
         _bus.Invoke(new ReplaceContainerCommand(restoredWindow, window.Parent, window.Index));
 
-        var workspace = WorkspaceService.GetWorkspaceFromChildContainer(window);
-        var insertionTarget = workspace.LastFocusedDescendantOfType<IResizable>();
+        // TODO: Temporary hack to resize restored window.
+        _bus.Invoke(
+          new MoveContainerWithinTreeCommand(
+            restoredWindow,
+            restoredWindow.Parent,
+            restoredWindow.Index,
+            true
+          )
+        );
 
-        // Insert the created tiling window after the last focused descendant of the workspace.
-        if (insertionTarget == null)
-          _bus.Invoke(new MoveContainerWithinTreeCommand(restoredWindow, workspace, 0, true));
-        else
-          _bus.Invoke(
-            new MoveContainerWithinTreeCommand(
-              restoredWindow,
-              insertionTarget.Parent,
-              insertionTarget.Index + 1,
-              true
-            )
-          );
-
-        _containerService.ContainersToRedraw.Add(workspace);
+        _containerService.ContainersToRedraw.Add(restoredWindow);
         _bus.Invoke(new RedrawContainersCommand());
       }
     }

--- a/GlazeWM.Domain/Windows/EventHandlers/WindowMinimizeEndedHandler.cs
+++ b/GlazeWM.Domain/Windows/EventHandlers/WindowMinimizeEndedHandler.cs
@@ -78,7 +78,8 @@ namespace GlazeWM.Domain.Windows.EventHandlers
         WindowType.Maximized => new MaximizedWindow(
           window.Handle,
           window.FloatingPlacement,
-          window.BorderDelta
+          window.BorderDelta,
+          WindowType.Tiling
         ),
         WindowType.Fullscreen => new FullscreenWindow(
           window.Handle,

--- a/GlazeWM.Domain/Windows/MaximizedWindow.cs
+++ b/GlazeWM.Domain/Windows/MaximizedWindow.cs
@@ -5,12 +5,16 @@ namespace GlazeWM.Domain.Windows
 {
   public sealed class MaximizedWindow : Window
   {
+    public WindowType PreviousState;
+
     public MaximizedWindow(
       IntPtr handle,
       Rect floatingPlacement,
-      RectDelta borderDelta
+      RectDelta borderDelta,
+      WindowType previousState
     ) : base(handle, floatingPlacement, borderDelta)
     {
+      PreviousState = previousState;
     }
   }
 }

--- a/GlazeWM.Domain/Windows/WindowService.cs
+++ b/GlazeWM.Domain/Windows/WindowService.cs
@@ -241,6 +241,7 @@ namespace GlazeWM.Domain.Windows
       {
         TilingWindow => WindowType.Tiling,
         FloatingWindow => WindowType.Floating,
+        MinimizedWindow => WindowType.Minimized,
         MaximizedWindow => WindowType.Maximized,
         FullscreenWindow => WindowType.Fullscreen,
         _ => throw new ArgumentException(null, nameof(window)),


### PR DESCRIPTION
when new windows are created and after switching worskpaces

Known issue currently: when a new window is spawned, it appears above the maximized window ✅ but when it closes, the next tiling/floating window gets focused ❌ 