### PR TITLE
fix: correct workspace size with Y offset and bar on bottom

### DIFF
--- a/GlazeWM.Domain/Workspaces/Workspace.cs
+++ b/GlazeWM.Domain/Workspaces/Workspace.cs
@@ -46,7 +46,7 @@ namespace GlazeWM.Domain.Workspaces
       get
       {
         var barPosition = _userConfigService.GetBarConfigForMonitor(Parent as Monitor).Position;
-        return barPosition == BarPosition.Top ? _logicalBarHeight : 0;
+        return barPosition == BarPosition.Top ? _logicalBarHeight : -_logicalBarHeight;
       }
     }
 
@@ -64,7 +64,8 @@ namespace GlazeWM.Domain.Workspaces
           return Parent.Height - _outerGaps.Top - _outerGaps.Bottom;
         }
 
-        return Parent.Height - _outerGaps.Top - _outerGaps.Bottom - floatBarOffsetY - _logicalBarHeight;
+        var barOffsetY = _userConfigService.GetBarConfigForMonitor(Parent as Monitor).Position == BarPosition.Bottom ? floatBarOffsetY : -floatBarOffsetY;
+        return Parent.Height - _outerGaps.Top - _outerGaps.Bottom + barOffsetY - _logicalBarHeight;
       }
     }
 


### PR DESCRIPTION
Correct size and offset of workspace when vertical offset is applied and bar is on the bottom.