### PR TITLE
fix: correct workspace size with Y offset and bar on bottom

### DIFF
--- a/GlazeWM.Domain/Workspaces/Workspace.cs
+++ b/GlazeWM.Domain/Workspaces/Workspace.cs
@@ -64,7 +64,7 @@ namespace GlazeWM.Domain.Workspaces
           return Parent.Height - _outerGaps.Top - _outerGaps.Bottom;
         }
 
-        return Parent.Height - _outerGaps.Top - _outerGaps.Bottom - floatBarOffsetY - _logicalBarHeight;
+        return Parent.Height - _outerGaps.Top - _outerGaps.Bottom - (barForMonitor.Position == BarPosition.Top ? floatBarOffsetY : -floatBarOffsetY) - _logicalBarHeight;
       }
     }
 
@@ -74,7 +74,7 @@ namespace GlazeWM.Domain.Workspaces
     {
       get
       {
-        if (!_userConfigService.GetBarConfigForMonitor(Parent as Monitor).Enabled)
+        if (!_userConfigService.GetBarConfigForMonitor(Parent as Monitor).Enabled || barForMonitor.Position == BarPosition.Bottom)
         {
           return Parent.Y + _outerGaps.Top;
         }


### PR DESCRIPTION
Fix workspace size and Y position when using `offsetY` bar config option with bar on the bottom