### PR TITLE
fix: system tray component expand on mouse button up

### DIFF
--- a/GlazeWM.Bar/Components/SystemTrayComponent.xaml
+++ b/GlazeWM.Bar/Components/SystemTrayComponent.xaml
@@ -18,7 +18,7 @@
       MouseEnter="OnLabelHoverEnter"
       MouseLeave="OnLabelHoverLeave">
       <i:Interaction.Triggers>
-        <i:EventTrigger EventName="MouseLeftButtonDown">
+        <i:EventTrigger EventName="MouseLeftButtonUp">
           <i:CallMethodAction
             MethodName="ToggleShowAllIcons"
             TargetObject="{Binding Path=DataContext, ElementName=_workspacesComponent, Mode=OneWay}" />


### PR DESCRIPTION
I've noticed that some system tray icons are getting triggered on expand if that icon is right under the expand arrow.
Changing the event trigger to MouseLeftButtonUp fixed the issue.