### PR TITLE
feat: option to disable floating windows initial centering

### DIFF
--- a/GlazeWM.App/Resources/sample-config.yaml
+++ b/GlazeWM.App/Resources/sample-config.yaml
@@ -15,13 +15,13 @@ general:
   # Amount to move floating windows by (eg. when using `alt+<hjkl>` on a floating window)
   floating_window_move_amount: "5%"
 
+  # Whether to center new floating windows.
+  center_new_floating_windows: true
+
   # *Strongly* recommended to set to 'false'. Whether to globally enable/disable
   # window transition animations (on minimize, close, etc). Set to 'unchanged'
   # to make no setting changes.
   window_animations: "unchanged"
-
-  # Whether to center new floating windows (default is true)
-  center_new_floating_windows: true
 
 gaps:
   # Gap between adjacent windows.

--- a/GlazeWM.App/Resources/sample-config.yaml
+++ b/GlazeWM.App/Resources/sample-config.yaml
@@ -20,6 +20,9 @@ general:
   # to make no setting changes.
   window_animations: "unchanged"
 
+  # Whether to center new floating windows (default is true)
+  center_new_floating_windows: true
+
 gaps:
   # Gap between adjacent windows.
   inner_gap: "20px"

--- a/GlazeWM.Domain/UserConfigs/GeneralConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/GeneralConfig.cs
@@ -27,7 +27,7 @@ namespace GlazeWM.Domain.UserConfigs
     /// </summary>
     public WindowAnimations WindowAnimations { get; set; } = WindowAnimations.Unchanged;
     /// <summary>
-    /// Weather to center new floating windows
+    /// Whether to center new floating windows
     /// </summary>
     public bool CenterNewFloatingWindows { get; set; } = true;
   }

--- a/GlazeWM.Domain/UserConfigs/GeneralConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/GeneralConfig.cs
@@ -26,5 +26,9 @@ namespace GlazeWM.Domain.UserConfigs
     /// Whether to enable window transition animations (on minimize, close, etc).
     /// </summary>
     public WindowAnimations WindowAnimations { get; set; } = WindowAnimations.Unchanged;
+    /// <summary>
+    /// Weather to center new floating windows
+    /// </summary>
+    public bool CenterNewFloatingWindows { get; set; } = true;
   }
 }

--- a/GlazeWM.Domain/Windows/CommandHandlers/ManageWindowHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/ManageWindowHandler.cs
@@ -87,14 +87,16 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
       return CommandResponse.Ok;
     }
 
-    private static Window CreateWindow(IntPtr windowHandle, Container targetParent)
+    private Window CreateWindow(IntPtr windowHandle, Container targetParent)
     {
       var originalPlacement = WindowService.GetPlacementOfHandle(windowHandle).NormalPosition;
 
       // Calculate where window should be placed when floating is enabled. Use the original
-      // width/height of the window, but position it in the center of the workspace.
+      // width/height of the window and optionally position it in the center of the workspace.
       var targetWorkspace = WorkspaceService.GetWorkspaceFromChildContainer(targetParent);
-      var floatingPlacement = originalPlacement.TranslateToCenter(targetWorkspace.ToRect());
+      var floatingPlacement = _userConfigService.GeneralConfig.CenterNewFloatingWindows
+        ? originalPlacement.TranslateToCenter(targetWorkspace.ToRect())
+        : originalPlacement;
 
       var defaultBorderDelta = new RectDelta(7, 0, 7, 7);
 

--- a/GlazeWM.Domain/Windows/CommandHandlers/ManageWindowHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/ManageWindowHandler.cs
@@ -91,12 +91,17 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
     {
       var originalPlacement = WindowService.GetPlacementOfHandle(windowHandle).NormalPosition;
 
+      var targetWorkspace = WorkspaceService.GetWorkspaceFromChildContainer(targetParent);
+      var handleWorkspace = _monitorService
+        .GetMonitorFromHandleLocation(windowHandle)
+        .DisplayedWorkspace;
+
       // Calculate where window should be placed when floating is enabled. Use the original
       // width/height of the window and optionally position it in the center of the workspace.
-      var targetWorkspace = WorkspaceService.GetWorkspaceFromChildContainer(targetParent);
-      var floatingPlacement = _userConfigService.GeneralConfig.CenterNewFloatingWindows
-        ? originalPlacement.TranslateToCenter(targetWorkspace.ToRect())
-        : originalPlacement;
+      var centerNewFloatingWindows = _userConfigService.GeneralConfig.CenterNewFloatingWindows;
+      var floatingPlacement = handleWorkspace == targetWorkspace && !centerNewFloatingWindows
+        ? originalPlacement
+        : originalPlacement.TranslateToCenter(targetWorkspace.ToRect());
 
       var defaultBorderDelta = new RectDelta(7, 0, 7, 7);
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ general:
   # Whether to globally enable/disable window transition animations (on minimize, close,
   # etc). Set to 'unchanged' to make no setting changes.
   window_animations: "unchanged"
+
+  # Whether to center new floating windows (default is true)
+  center_new_floating_windows: true
 ```
 
 ## Keybindings


### PR DESCRIPTION
Issue: some apps (Autodesk Maya, 3ds Max) have a workflow of creating floating windows constantly. Setting a rule of "set floating" to those windows will center them on the screen every time you open them. By default, those apps keep the position of those windows internally, but GlazeWM will treat them as new windows every time and center them (even within one session).

Solution: have an option to disable initial centering of newly created floating windows. Default behavior will not change, unless the user decides to set the option to false. I keep it constantly to false in my build.

Possible issues: I haven't tested this on a multi-monitor setup, as I don't use multiple screens.

Partially closes the (#436)