### PR TITLE
fix: workspace shouldn't be flattened

### DIFF
--- a/GlazeWM.Domain/Containers/CommandHandlers/DetachContainerHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/DetachContainerHandler.cs
@@ -75,8 +75,8 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
         _bus.Invoke(
           new FlattenSplitContainerCommand(detachedSiblings.ElementAt(0) as SplitContainer)
         );
-
-        _bus.Invoke(new FlattenSplitContainerCommand(detachedParent as SplitContainer));
+        if (detachedParent is not Workspace)
+          _bus.Invoke(new FlattenSplitContainerCommand(detachedParent as SplitContainer));
       }
 
       return CommandResponse.Ok;


### PR DESCRIPTION
Imagine a workspace with three windows.

![fig1](https://github.com/glazerdesktop/GlazeWM/assets/56078314/c3558a64-ecd9-4cf4-8225-d1c67ec95e25)

Closing (detaching) TW1 triggers the following section: 

https://github.com/glazerdesktop/GlazeWM/blob/18eb8c80ceaf166eaf6c74b7a3846871e18db9ae/GlazeWM.Domain/Containers/CommandHandlers/DetachContainerHandler.cs#L70-L80

in this case, `detachedSiblings[0]` refers to the `splitContainer`, and `detachedParent` is the workspace. The `splitContainer` flattens correctly, but then flattening the workspace causes its deletion, directly attaching `TW2` and `TW3` to the monitor.

Then during redrawing, `TW2` and `TW3` can't find their workspace ancestor, leading to the exception `Sequence contains no elements`.
https://github.com/glazerdesktop/GlazeWM/blob/18eb8c80ceaf166eaf6c74b7a3846871e18db9ae/GlazeWM.Domain/Containers/CommandHandlers/RedrawContainersHandler.cs#L79

The fix is just adding a conditional check to whether `detachedParent` is a workspace. But there might be potential problems that might arise from executing the flatten command.